### PR TITLE
Pass annotations through ExternalSecrets

### DIFF
--- a/lib/daemon.js
+++ b/lib/daemon.js
@@ -36,7 +36,7 @@ class Daemon {
    * @returns {Object} Poller descriptor.
    */
   _createPollerDescriptor (externalSecret) {
-    const { uid, name, namespace } = externalSecret.metadata
+    const { uid, name, namespace, annotations } = externalSecret.metadata
     // NOTE(jdaeli): hash this in case resource version becomes too long?
     const secretDescriptor = { ...externalSecret.secretDescriptor, name }
     const ownerReference = {
@@ -47,7 +47,7 @@ class Daemon {
       uid
     }
 
-    return { id: uid, namespace, secretDescriptor, ownerReference }
+    return { id: uid, namespace, secretDescriptor, ownerReference, annotations }
   }
 
   /**
@@ -75,6 +75,7 @@ class Daemon {
       kubeClient: this._kubeClient,
       logger: this._logger,
       namespace: descriptor.namespace,
+      annotations: descriptor.annotations,
       secretDescriptor: descriptor.secretDescriptor,
       ownerReference: descriptor.ownerReference
     })

--- a/lib/poller.js
+++ b/lib/poller.js
@@ -24,6 +24,7 @@ class Poller {
    * @param {SecretDescriptor} secretDescriptor - Kubernetes secret descriptor.
    */
   constructor ({
+    annotations,
     backends,
     intervalMilliseconds,
     kubeClient,
@@ -32,6 +33,7 @@ class Poller {
     secretDescriptor,
     ownerReference
   }) {
+    this._annotations = annotations
     this._backends = backends
     this._intervalMilliseconds = intervalMilliseconds
     this._kubeClient = kubeClient
@@ -55,6 +57,7 @@ class Poller {
       apiVersion: 'v1',
       kind: 'Secret',
       metadata: {
+        annotations: this._annotations,
         name: secretDescriptor.name,
         ownerReferences: [
           this._ownerReference


### PR DESCRIPTION
This PR fixes https://github.com/godaddy/kubernetes-external-secrets/issues/137 and allows annotations to be passed through ExternalSecrets to Secrets